### PR TITLE
Do not try to resolve object if graphql id cannot be parsed

### DIFF
--- a/honeypot-rails_core_tools.gemspec
+++ b/honeypot-rails_core_tools.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'honeypot-rails_core_tools'
-  spec.version       = '0.0.2'
+  spec.version       = '0.0.3'
   spec.authors       = ['Andrzej Trzaska']
   spec.email         = ['atrzaska2@gmail.com']
 

--- a/lib/honeypot/rails_core_tools.rb
+++ b/lib/honeypot/rails_core_tools.rb
@@ -29,6 +29,8 @@ module Honeypot
       type, id, provided_digest = graphql_id.split('.')
       type_and_id = "#{type}.#{id}"
 
+      return if type.nil? && id.nil? && provided_digest.nil?
+
       raise 'Invalid digest' if provided_digest != digest(type_and_id)
 
       gid = "gid://#{GlobalID.app}/#{type}/#{id}"


### PR DESCRIPTION
in case provided id is not graphql ID we can do a early null return